### PR TITLE
fix "TypeError: Cannot read property 'ownerDocument' of null" on try …

### DIFF
--- a/src/resource.ts
+++ b/src/resource.ts
@@ -131,6 +131,7 @@ class Resource extends BaseResource {
         }, {
           new: true,
           runValidators: true,
+          context: 'query'
         })
         return Resource.stringifyId(mongooseObject.toObject())
       } catch (error) {

--- a/src/resource.ts
+++ b/src/resource.ts
@@ -131,7 +131,7 @@ class Resource extends BaseResource {
         }, {
           new: true,
           runValidators: true,
-          context: 'query'
+          context: 'query',
         })
         return Resource.stringifyId(mongooseObject.toObject())
       } catch (error) {


### PR DESCRIPTION
When trying to update the document with a unique validation plugin have error `Cannot read property 'ownerDocument' of null`
![image](https://user-images.githubusercontent.com/52565381/100732888-ae44f880-33cd-11eb-8672-9425478666f4.png)

I fix it by adding the option context: `{..., context: 'query'}`. Docs [mongoose-unique-validator](https://github.com/blakehaswell/mongoose-unique-validator#find--updates)
