### PR TITLE
chore: showing schema alias as the property name

### DIFF
--- a/src/property.ts
+++ b/src/property.ts
@@ -62,7 +62,7 @@ class Property extends BaseProperty {
     }
 
     name() {
-      return this.mongoosePath.path
+      return this.mongoosePath.options.alias || this.mongoosePath.path
     }
 
     isEditable() {


### PR DESCRIPTION
For properties that are using using `alias` (for example, in a large scale database or a large collection, it's preferred to use the alias to improve the performance and get more space).

We can define the Schema with an alias like below:

```typescript
const Schema: Schema = new Schema({
  a: { type: String, alias: 'action' },
  u: { type: Types.ObjectId, ref: `User`, alias: 'user'}
})
```
But the AdminJS will show the shorten name in Dashboard.
This update will let AdminJS handling the alias as the property name instead.

The dashboard will look likes this:
<img width="619" alt="image" src="https://user-images.githubusercontent.com/5009534/126888769-fa8b5143-fc62-4375-ab2f-ddd66272bce8.png">

The MongoDB data:
<img width="592" alt="image" src="https://user-images.githubusercontent.com/5009534/126888842-0a15b953-2ec0-43f0-8974-26e877750a92.png">

