### PR TITLE
Use estimatedDocumentCount instead of count

### DIFF
--- a/src/resource.ts
+++ b/src/resource.ts
@@ -67,7 +67,7 @@ class Resource extends BaseResource {
     }
 
     async count(filters = null) {
-      return this.MongooseModel.count(convertFilter(filters))
+      return this.MongooseModel.find(convertFilter(filters)).estimatedDocumentCount();
     }
 
     async find(filters = {}, { limit = 20, offset = 0, sort = {} }: FindOptions) {


### PR DESCRIPTION
## Overview

`Model.count()` is deprecated https://mongoosejs.com/docs/api.html#model_Model.count and actually doesn't work properly with massive collections (+2M records).

Use `estimatedDocumentCount` instead of `count` as recommended by Mongoose. Also, it fixes a bug where `count` won't work if the collection has more than 2M records. I tested myself in a project.