### PR TITLE
feat: use countdocuments method

### DIFF
--- a/src/resource.ts
+++ b/src/resource.ts
@@ -70,7 +70,7 @@ class Resource extends BaseResource {
       if (Object.keys(convertFilter(filters)).length > 0) {
         return this.MongooseModel.count(convertFilter(filters))
       }
-      return this.MongooseModel.estimatedDocumentCount()
+      return this.MongooseModel.countDocuments()
     }
 
     async find(filters = {}, { limit = 20, offset = 0, sort = {} }: FindOptions) {


### PR DESCRIPTION
`countDocuments` method use the pre count hook and then we got the right number of items

For example:
I have 'users' collection in mongoDB and I use the next models:
```
const userSchema = new Schema({
    name: String,
    is_staff: Boolean
});

const Users = mongoose.model('user', userSchema);

const staffSchema = new Schema({
    email: String
}).add(userSchema);

const Staff = mongoose.model('staff', staffSchema, 'users');

const findQueryTypes = ['count', 'find', ...];

findQueryTypes.forEach(type => {
    staffSchema.pre(type, function (next) {
        const query = { is_staff: true };  
        this.where(query);
    
        next();
    });
});
```

Both models use the `users` collection but in the Staff list page I expect to receive only the staff members from the `users` collection - and it's works - But the count number next to the List label is still same as in the Users page


![image](https://user-images.githubusercontent.com/91004029/188305224-04d374aa-9d09-4770-a837-d212bf4046db.png)

![image](https://user-images.githubusercontent.com/91004029/188305231-d61fbdec-a272-4613-b835-8fdf392ec804.png)
