### PR TITLE
fix: Support defining field references by passing Model instance

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -10,11 +10,11 @@ jobs:
           GITHUB_CONTEXT: ${{ toJson(github) }}
         run: echo "$GITHUB_CONTEXT"
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Setup
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
-          node-version: '10.x'
+          node-version: 18
       - uses: actions/cache@v1
         id: yarn-cache
         with:
@@ -37,11 +37,11 @@ jobs:
           - 27017:27017
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Setup
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
-          node-version: '10.x'
+          node-version: 18
       - uses: actions/cache@v1
         id: yarn-cache
         with:

--- a/src/property.ts
+++ b/src/property.ts
@@ -70,10 +70,13 @@ class Property extends BaseProperty {
     }
 
     reference() {
-      if (this.isArray()) {
-        return this.mongoosePath.caster.options && this.mongoosePath.caster.options.ref
-      }
-      return this.mongoosePath.options && this.mongoosePath.options.ref
+      const ref = this.isArray()
+        ? this.mongoosePath.caster.options?.ref
+        : this.mongoosePath.options?.ref
+
+      if (typeof ref === 'function') return ref.modelName
+
+      return ref
     }
 
     isVisible() {


### PR DESCRIPTION
Right now AdminJS throws 500 when using Model instances for field references.

But, mongoose supports defining references in fields by passing in the Model instance.

Example: 

<img width="311" alt="image" src="https://user-images.githubusercontent.com/4000963/197253027-47096a67-fb01-48f7-a164-74ae90153b3c.png">

This PR allows AdminJS to work with this pattern. 