### PR TITLE
fix: ObjectID into camel case

### DIFF
--- a/src/property.ts
+++ b/src/property.ts
@@ -50,6 +50,7 @@ class Property extends BaseProperty {
       case 'Embedded':
         return 'mixed'
       case 'ObjectID':
+      case 'ObjectId':
         if (this.reference()) {
           return 'reference'
         }


### PR DESCRIPTION
Mongoose 7.00 brings a breaking change in the form of updating the ObjectID to ObjectId