### PR TITLE
chore: mark `mongoose@8` as unsupported

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "homepage": "https://github.com/SoftwareBrothers/adminjs-mongoose#readme",
   "peerDependencies": {
     "adminjs": "^7.0.0",
-    "mongoose": ">=5"
+    "mongoose": ">=5 <8"
   },
   "dependencies": {
     "escape-regexp": "0.0.1",


### PR DESCRIPTION
This library doesn't work with [`mongoose@8`][1]. At the very least, `mongoose@8` [drops support][2] for `.count()`, which this library [still uses][3].

As a quick note to other developers, this change updates the peer dependency requirement to not include `mongoose@8`.

[1]: https://github.com/Automattic/mongoose/blob/master/CHANGELOG.md#800-rc0--2023-10-24
[2]: https://github.com/Automattic/mongoose/pull/13618
[3]: https://github.com/SoftwareBrothers/adminjs-mongoose/blob/fd8ad92e81da8f61da6759e2c4c9a020d88bc2b6/src/resource.ts#L71