### PR TITLE
fix: resolve nested array creation issue

### DIFF
--- a/src/resource.ts
+++ b/src/resource.ts
@@ -108,7 +108,8 @@ class Resource extends BaseResource {
 
   async create(params) {
     const parsedParams = this.parseParams(params)
-    let mongooseDocument = new this.MongooseModel(parsedParams)
+    const unflattedParams = flat.unflatten(parsedParams)
+    let mongooseDocument = new this.MongooseModel(unflattedParams)
     try {
       mongooseDocument = await mongooseDocument.save()
     } catch (error) {


### PR DESCRIPTION
Fixed an issue where nested arrays were incorrectly saved as objects during initial creation, resulting in an unexpected data structure. With this fix, nested arrays are now properly initialized and stored as arrays, aligning with expected behavior.

Example of the issue:
Input: ['the', 'issue']
Saved in DB (before fix): { '0': 'the', '1': 'issue' }

Interestingly, this issue only occurred on record creation, while updating a record saved arrays correctly.
